### PR TITLE
Fixes issue with jsonapi-serializable no longer calling to_json

### DIFF
--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
-  spec.add_dependency 'jsonapi-serializable', '~> 0.1', '>= 0.1.3'
-  spec.add_dependency 'jsonapi-deserializable', '~> 0.1'
+  spec.add_dependency 'jsonapi-rb', '~> 0.1', '>= 0.1.3'
 
   spec.add_development_dependency 'rails', '~> 5.0'
   spec.add_development_dependency 'sqlite3'

--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
-  spec.add_dependency 'jsonapi-rb', '~> 0.1'
+  spec.add_dependency 'jsonapi-serializable', '~> 0.1', '>= 0.1.3'
+  spec.add_dependency 'jsonapi-deserializable', '~> 0.1'
 
   spec.add_development_dependency 'rails', '~> 5.0'
   spec.add_development_dependency 'sqlite3'

--- a/lib/jsonapi/rails/renderer.rb
+++ b/lib/jsonapi/rails/renderer.rb
@@ -32,8 +32,7 @@ module JSONAPI
         # has access to the request object.
         reverse_mapping = request.env[ActionController::REVERSE_MAPPING_KEY]
         options = options.merge(_reverse_mapping: reverse_mapping)
-        json = renderer.render(json, options) unless json.is_a?(String)
-        json = json.to_json unless json.is_a?(String)
+        json = renderer.render(json, options).to_json unless json.is_a?(String)
         self.content_type ||= Mime[:jsonapi]
         self.response_body = json
       end

--- a/lib/jsonapi/rails/renderer.rb
+++ b/lib/jsonapi/rails/renderer.rb
@@ -33,6 +33,7 @@ module JSONAPI
         reverse_mapping = request.env[ActionController::REVERSE_MAPPING_KEY]
         options = options.merge(_reverse_mapping: reverse_mapping)
         json = renderer.render(json, options) unless json.is_a?(String)
+        json = json.to_json unless json.is_a?(String)
         self.content_type ||= Mime[:jsonapi]
         self.response_body = json
       end


### PR DESCRIPTION
This is a very simple implementation, and you might have something else in mind, but it fixes the issue of `jsonapi-serializable` no longer calling `.to_json` as of jsonapi-rb/jsonapi-serializable#56.

Tests pass for currently released versions, as well as `master`.

Not having this, breaks any requests in Rails that use 
```ruby
render jsonapi: resource
```
to render data.