### PR TITLE
Expose deserialization reverse mapping in controllers

### DIFF
--- a/lib/jsonapi/rails/action_controller.rb
+++ b/lib/jsonapi/rails/action_controller.rb
@@ -4,6 +4,8 @@ require 'jsonapi/parser'
 module JSONAPI
   module Rails
     module ActionController
+      extend ActiveSupport::Concern
+
       REVERSE_MAPPING_KEY = 'jsonapi_deserializable.reverse_mapping'.freeze
 
       module ClassMethods
@@ -29,6 +31,12 @@ module JSONAPI
             controller.params[key.to_sym] = resource.to_hash
           end
         end
+      end
+
+      private
+
+      def jsonapi_pointers
+        request.env[REVERSE_MAPPING_KEY]
       end
     end
   end

--- a/lib/jsonapi/rails/action_controller.rb
+++ b/lib/jsonapi/rails/action_controller.rb
@@ -6,9 +6,9 @@ module JSONAPI
     module ActionController
       extend ActiveSupport::Concern
 
-      REVERSE_MAPPING_KEY = 'jsonapi_deserializable.reverse_mapping'.freeze
+      JSONAPI_POINTERS_KEY = 'jsonapi_deserializable.jsonapi_pointers'.freeze
 
-      module ClassMethods
+      class_methods do
         def deserializable_resource(key, options = {}, &block)
           _deserializable(key, options,
                           JSONAPI::Deserializable::Resource, &block)
@@ -26,7 +26,7 @@ module JSONAPI
 
           before_action(options) do |controller|
             resource = klass.new(controller.params[:_jsonapi].to_unsafe_hash)
-            controller.request.env[REVERSE_MAPPING_KEY] =
+            controller.request.env[JSONAPI_POINTERS_KEY] =
               resource.reverse_mapping
             controller.params[key.to_sym] = resource.to_hash
           end
@@ -36,7 +36,7 @@ module JSONAPI
       private
 
       def jsonapi_pointers
-        request.env[REVERSE_MAPPING_KEY]
+        request.env[JSONAPI_POINTERS_KEY]
       end
     end
   end

--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -17,7 +17,7 @@ module JSONAPI
       initializer 'jsonapi-rails.action_controller' do
         ActiveSupport.on_load(:action_controller) do
           require 'jsonapi/rails/action_controller'
-          extend ::JSONAPI::Rails::ActionController::ClassMethods
+          include ::JSONAPI::Rails::ActionController
 
           Mime::Type.register MEDIA_TYPE, :jsonapi
 
@@ -35,9 +35,8 @@ module JSONAPI
 
           ::ActionController::Renderers.add(:jsonapi_error) do |errors, options|
             # Renderer proc is evaluated in the controller context, so it
-            # has access to the request object.
-            reverse_mapping = request.env[ActionController::REVERSE_MAPPING_KEY]
-            options = options.merge(_reverse_mapping: reverse_mapping)
+            # has access to the jsonapi_pointers method.
+            options = options.merge(_jsonapi_pointers: jsonapi_pointers)
             self.content_type ||= Mime[:jsonapi]
 
             RENDERERS[:jsonapi_error].render(errors, options).to_json

--- a/spec/action_controller_spec.rb
+++ b/spec/action_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe JSONAPI::Rails::ActionController do
+  class TestController < ActionController::Base
+    deserializable_resource "things"
+  end
+
+  let(:controller) { TestController.new }
+
+  context 'source pointers' do
+    it 'should fetch the mapping created during deserialization' do
+      reverse_mapping = {id: "/data/id", type: "/data/type"}
+      allow(controller).to receive(:request) do
+        OpenStruct.new(env: {'jsonapi_deserializable.reverse_mapping' => reverse_mapping})
+      end
+      expect(controller.send(:jsonapi_pointers)).to equal reverse_mapping
+    end
+  end
+end

--- a/spec/action_controller_spec.rb
+++ b/spec/action_controller_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe JSONAPI::Rails::ActionController do
-  class TestController < ActionController::Base
-    deserializable_resource "things"
-  end
+RSpec.describe ActionController::Base do
+  it 'exposes the deserialization mapping via the jsonapi_pointers method' do
+    pointers = { id: '/data/id', type: '/data/type' }
 
-  let(:controller) { TestController.new }
-
-  context 'source pointers' do
-    it 'should fetch the mapping created during deserialization' do
-      reverse_mapping = {id: "/data/id", type: "/data/type"}
-      allow(controller).to receive(:request) do
-        OpenStruct.new(env: {'jsonapi_deserializable.reverse_mapping' => reverse_mapping})
-      end
-      expect(controller.send(:jsonapi_pointers)).to equal reverse_mapping
+    allow(subject).to receive(:request) do
+      OpenStruct.new(
+        env: {
+          JSONAPI::Rails::ActionController::JSONAPI_POINTERS_KEY => pointers
+        }
+      )
     end
+
+    expect(subject.send(:jsonapi_pointers)).to equal pointers
   end
 end


### PR DESCRIPTION
Adds a `jsonapi_pointers` instance method in the controller to access the json pointers generated during deserialization. See #27.