### PR TITLE
Add hook for automatic pagination links.

### DIFF
--- a/lib/jsonapi/rails/action_controller.rb
+++ b/lib/jsonapi/rails/action_controller.rb
@@ -42,6 +42,10 @@ module JSONAPI
         end
       end
 
+      def jsonapi_pagination(_collection)
+        nil
+      end
+
       def jsonapi_pointers
         request.env[JSONAPI_POINTERS_KEY]
       end

--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -30,6 +30,12 @@ module JSONAPI
           ::ActionController::Renderers.add(:jsonapi) do |resources, options|
             self.content_type ||= Mime[:jsonapi]
 
+            # Renderer proc is evaluated in the controller context, so it
+            # has access to the jsonapi_pagination method.
+            if (pagination_links = jsonapi_pagination(resources))
+              (options[:links] ||= {}).merge!(pagination_links)
+            end
+
             RENDERERS[:jsonapi].render(resources, options).to_json
           end
 


### PR DESCRIPTION
Closes #28. On top of #34.

Introduces a `jsonapi_pagination` hook in `ActionController::Base` that can be used to inject a hash of pagination links.

Example:

```ruby
class ApplicationController < ActionController::Base
  def jsonapi_pagination(collection)
    { first: ..., last: ..., prev: ..., next: ... } if collection.paginated?
  end
end
```