### PR TITLE
Adding with_indiferent_access to controller params

### DIFF
--- a/lib/jsonapi/rails/controller/deserialization.rb
+++ b/lib/jsonapi/rails/controller/deserialization.rb
@@ -49,7 +49,8 @@ module JSONAPI
                     Class.new(JSONAPI::Rails::DeserializableResource, &block)
 
             before_action(options) do |controller|
-              hash = controller.params.to_unsafe_hash[:_jsonapi]
+              hash = controller.params.to_unsafe_hash
+                .with_indifferent_access[:_jsonapi]
               if hash.nil?
                 JSONAPI::Rails.logger.warn do
                   "Unable to deserialize #{key} because no JSON API payload was" \


### PR DESCRIPTION
In Rails 4.2, `to_unsafe_hash` converts the `params` to a Hash and the
values can only be accessed with the keys as strings.

This change allows for compatibility with Rails 4.2.