### PR TITLE
Do not redefine renderers

### DIFF
--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -47,6 +47,9 @@ module JSONAPI
       def register_renderers
         ActiveSupport.on_load(:action_controller) do
           RENDERERS.each do |name, renderer|
+            # Avoid warning: method redefined
+            next if ::ActionController::Renderers::RENDERERS.include?(name)
+
             ::ActionController::Renderers.add(name) do |resources, options|
               # Renderer proc is evaluated in the controller context.
               self.content_type ||= Mime[:jsonapi]


### PR DESCRIPTION
When I run specs on my service which use jsonapi-rails I see a lot of warnings:

```
.../gems/ruby-2.3.4/gems/actionpack-5.1.4/lib/action_controller/metal/renderers.rb:75: warning: method redefined; discarding old _render_with_renderer_jsonapi
.../gems/ruby-2.3.4/gems/jsonapi-rails-0.3.1/lib/jsonapi/rails/railtie.rb:51: warning: previous definition of _render_with_renderer_jsonapi was here
.../gems/ruby-2.3.4/gems/actionpack-5.1.4/lib/action_controller/metal/renderers.rb:75: warning: method redefined; discarding old _render_with_renderer_jsonapi_errors
.../gems/ruby-2.3.4/gems/jsonapi-rails-0.3.1/lib/jsonapi/rails/railtie.rb:51: warning: previous definition of _render_with_renderer_jsonapi_errors was here
```

Gemfile.lock:
```
    ...
    jsonapi-deserializable (0.2.0)
    jsonapi-parser (0.1.1)
    jsonapi-rails (0.3.1)
      jsonapi-parser (~> 0.1.0)
      jsonapi-rb (~> 0.5.0)
    jsonapi-rb (0.5.0)
      jsonapi-deserializable (~> 0.2.0)
      jsonapi-serializable (~> 0.3.0)
    jsonapi-renderer (0.2.0)
    jsonapi-serializable (0.3.0)
      jsonapi-renderer (~> 0.2.0)
    ...
```

This PR solve this. Not sure that this is the right way but it works.