### PR TITLE
Teach generator to respect namespaces

### DIFF
--- a/lib/generators/jsonapi/serializable/serializable_generator.rb
+++ b/lib/generators/jsonapi/serializable/serializable_generator.rb
@@ -8,10 +8,18 @@ module Jsonapi
     def copy_serializable_file
       template 'serializable.rb.erb',
                File.join('app/serializable', class_path,
-                         "serializable_#{file_name}.rb")
+                         "#{serializable_file_name}.rb")
     end
 
     private
+
+    def serializable_file_name
+      "serializable_#{file_name}"
+    end
+
+    def serializable_class_name
+      (class_path + [serializable_file_name]).map!(&:camelize).join("::")
+    end
 
     def model_klass
       # TODO(beauby): Ensure the model class exists.

--- a/lib/generators/jsonapi/serializable/serializable_generator.rb
+++ b/lib/generators/jsonapi/serializable/serializable_generator.rb
@@ -27,7 +27,7 @@ module Jsonapi
     end
 
     def type
-      model_klass.name.underscore.pluralize
+      model_klass.model_name.plural
     end
 
     def attr_names

--- a/lib/generators/jsonapi/serializable/templates/serializable.rb.erb
+++ b/lib/generators/jsonapi/serializable/templates/serializable.rb.erb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class Serializable<%= class_name %> < JSONAPI::Serializable::Resource
+class <%= serializable_class_name %> < JSONAPI::Serializable::Resource
   type '<%= type %>'
 <% attr_names.each do |attr| -%>
   attribute :<%= attr %>


### PR DESCRIPTION
Fixes the issue with namespaced models.

## `rails generate jsonapi:serializable Blog::Post` 

### Before: 

1. generates `app/serializables/blog/serializable_post.rb` file with `SerializableBlog::Post` class inside.
2. produces `type 'blog/posts'`
 
### After: 

1. generates `app/serializables/blog/serializable_post.rb` file with `Blog::SerializablePost` class inside.
2. produces `type 'blog_posts'`
 