### PR TITLE
map `:base` attribute to `'/data'` if not used as an attribute

### DIFF
--- a/lib/jsonapi/rails/serializable_active_model_errors.rb
+++ b/lib/jsonapi/rails/serializable_active_model_errors.rb
@@ -17,9 +17,13 @@ module JSONAPI
 
     # @private
     class SerializableActiveModelErrors
+      BASE_ERRORS_MAPPING = { base: '/data' }.freeze
+
       def initialize(exposures)
         @errors = exposures[:object]
-        @reverse_mapping = exposures[:_jsonapi_pointers] || {}
+        @reverse_mapping = BASE_ERRORS_MAPPING.merge(
+          exposures[:_jsonapi_pointers] || {}
+        )
 
         freeze
       end


### PR DESCRIPTION
The [specification](https://jsonapi.org/format/#error-objects) for `"/data"` in a JSONAPI error object's `source` attribute and the [suggested usage of `:base`](https://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-add) in ActiveModel::Error seem aligned.

Wrote this such that any actual `:base` attribute would override this, but not sure what sort of tests need to be added or whether it's worth adding at all.