### PR TITLE
Make SerializableGenerator to check that given model exists

### DIFF
--- a/lib/generators/jsonapi/serializable/serializable_generator.rb
+++ b/lib/generators/jsonapi/serializable/serializable_generator.rb
@@ -6,12 +6,20 @@ module Jsonapi
     # TODO(beauby): Implement versioning.
 
     def copy_serializable_file
+      fail "#{class_name} model not found." unless model_exists?
+
       template 'serializable.rb.erb',
                File.join('app/serializable', class_path,
                          "#{serializable_file_name}.rb")
     end
 
     private
+
+    def model_exists?
+      Rails.application.eager_load!
+      models = ApplicationRecord.descendants.map(&:name)
+      !!models.find { |model_name| model_name == class_name }
+    end
 
     def serializable_file_name
       "serializable_#{file_name}"
@@ -22,7 +30,6 @@ module Jsonapi
     end
 
     def model_klass
-      # TODO(beauby): Ensure the model class exists.
       class_name.safe_constantize
     end
 

--- a/spec/serializable_generator_spec.rb
+++ b/spec/serializable_generator_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require 'rails/generators'
+require_relative File.expand_path("../../lib/generators/jsonapi/serializable/serializable_generator.rb", __FILE__)
+
+describe Jsonapi::SerializableGenerator do
+  with_model :User, superclass: ApplicationRecord, scope: :all do
+    table do |t|
+      t.string :name
+      t.string :email
+    end
+  end
+
+  before do
+    @test_case = Rails::Generators::TestCase.new(:fake_test_case)
+    @test_case.class.tests(described_class)
+    @test_case.class.destination(File.expand_path("../tmp", File.dirname(__FILE__)))
+    @test_case.send(:prepare_destination)
+  end
+
+  context "passing an existent model" do
+    let(:model_name) { "User" }
+
+    it "creates a serializable resource" do
+      @test_case.assert_no_file "app/serializable/serializable_user.rb"
+      @test_case.run_generator([model_name])
+      @test_case.assert_file "app/serializable/serializable_user.rb", /SerializableUser/
+    end
+  end
+
+  context "passing an nonexistent model" do
+    let(:model_name) { "Dummy" }
+
+    it "raises an error" do
+     expect { @test_case.run_generator([model_name]) }.to raise_error(RuntimeError, "Dummy model not found.")
+    end
+
+    it "does not create a serializable resource" do
+      @test_case.assert_no_file "app/serializable/serializable_dummy.rb" do
+        @test_case.run_generator([model_name])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #71 
* Raises a `RuntimeError` if model is not found
* Prevents creating the serializer if model is not found
* Tests for the generator make use of `Rails::Generators::TestCase` (https://api.rubyonrails.org/v5.2.2/classes/Rails/Generators/TestCase.html#method-i-assert_directory). They are intended to be used with Minitest but I managed to make it work with RSpec