### PR TITLE
Adding the minimum rack version required to gemspec

### DIFF
--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'jsonapi-rb', '~> 0.5.0'
   spec.add_dependency 'jsonapi-parser', '~> 0.1.0'
+  spec.add_dependency 'rack', '~> 2.0.7'
 
   spec.add_development_dependency 'rails', '~> 5.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'


### PR DESCRIPTION
When installing jsonapi-rails on a Rails 4.1.6 project with Rack 1.5.5 I got an error that the application could not load "rack/media_type". Rack::MediaType was added in Rack v 2.0.7 as per this commit: https://github.com/rack/rack/commit/a193c5763de43bd61c5b4a13cd05497247b5cadb#diff-6f6cb23995312fff1e356f47a3e2a51f.

Credit to @albertxie for pointing this error out.

--- 

### Before

Before adding this line I could add the `jsonapi-rails` gem and run `bundle install`. But I ran into this error when I ran `rails c`.

```
/Users/cassidy/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/activesupport-4.1.16/lib/active_support/dependencies.rb:247:in `require': cannot load such file -- rack/media_type (LoadError)
        from /Users/cassidy/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/activesupport-4.1.16/lib/active_support/dependencies.rb:247:in `block in require'
        from /Users/cassidy/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/activesupport-4.1.16/lib/active_support/dependencies.rb:232:in `load_dependency'
        from /Users/cassidy/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/activesupport-4.1.16/lib/active_support/dependencies.rb:247:in `require'
        from /Users/cassidy/.rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/bundler/gems/jsonapi-rails-716e18b1cc84/lib/jsonapi/rails/filter_media_type.rb:1:in `<top (required)>'
```

### After

After adding this change to the gemspec and running bundle install, I get an informative error:

```
Resolving dependencies......
Bundler could not find compatible versions for gem "rack":
  In snapshot (Gemfile.lock):
    rack (= 1.5.5)

  In Gemfile:
    activeadmin (~> 1.0.0.pre5) was resolved to 1.0.0.pre5, which depends on
      formtastic (~> 3.1) was resolved to 3.1.5, which depends on
        actionpack (>= 3.2.13) was resolved to 4.1.16, which depends on
          rack (~> 1.5.2)

    jsonapi-rails was resolved to 0.4.0, which depends on
      rack (~> 2.0.7)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

