### PR TITLE
fix rails deprecation warning messages 

### DIFF
--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jsonapi-parser', '~> 0.1.0'
 
   spec.add_development_dependency 'rails', '~> 5.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
+  spec.add_development_dependency 'sqlite3', '~> 1.4'
   spec.add_development_dependency 'rake',        '~> 11.3'
   spec.add_development_dependency 'rspec-rails', '~> 3.5'
   spec.add_development_dependency 'with_model',  '~> 2.0'

--- a/lib/jsonapi/rails/serializable_active_model_errors.rb
+++ b/lib/jsonapi/rails/serializable_active_model_errors.rb
@@ -25,7 +25,7 @@ module JSONAPI
       end
 
       def as_jsonapi
-        @errors.keys.flat_map do |key|
+        @errors.attribute_names.flat_map do |key|
           @errors.full_messages_for(key).map do |message|
             SerializableActiveModelError.new(field: key, message: message,
                                              pointer: @reverse_mapping[key])


### PR DESCRIPTION
Fixes:
```
DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.

To achieve the same use:

  errors.attribute_names
```

Closes #127

Also, upgraded sqlite to 1.4.