### PR TITLE
removing deprecation warning from using keys instead of attribute_names

### DIFF
--- a/lib/jsonapi/rails/serializable_active_model_errors.rb
+++ b/lib/jsonapi/rails/serializable_active_model_errors.rb
@@ -25,7 +25,7 @@ module JSONAPI
       end
 
       def as_jsonapi
-        @errors.keys.flat_map do |key|
+        @errors.attribute_names.flat_map do |key|
           @errors.full_messages_for(key).map do |message|
             SerializableActiveModelError.new(field: key, message: message,
                                              pointer: @reverse_mapping[key])


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.

To achieve the same use:

  errors.attribute_names
```

Closes #127