### PR TITLE
Guard valid content type check against bad Content-Type

### DIFF
--- a/lib/jsonapi/rails/filter_media_type.rb
+++ b/lib/jsonapi/rails/filter_media_type.rb
@@ -20,7 +20,7 @@ module JSONAPI
 
       def valid_content_type?(content_type)
         Rack::MediaType.type(content_type) != JSONAPI_MEDIA_TYPE ||
-          Rack::MediaType.params(content_type) == {}
+          content_type == JSONAPI_MEDIA_TYPE
       end
 
       def valid_accept?(accept)

--- a/spec/filter_media_type_spec.rb
+++ b/spec/filter_media_type_spec.rb
@@ -27,6 +27,14 @@ describe JSONAPI::Rails::FilterMediaType do
     end
   end
 
+  context 'when receiving a bad Content-Type' do
+    it 'fails with 415 Unsupported Media Type' do
+      env = { 'CONTENT_TYPE' => 'application/vnd.api+json, application/vnd.api+json' }
+
+      expect(described_class.new(app).call(env)[0]).to eq(415)
+    end
+  end
+
   context 'when not receiving JSON API in Accept' do
     it 'passes through' do
       env = { 'HTTP_ACCEPT' => 'application/json' }


### PR DESCRIPTION
### Purpose

Avoid `undefined method 'start_with?' for nil:NilClass` in `Rack::MediaType` `strip_doublequotes` when given a bad content type.

### Additional helpful information

Given:

> Clients MUST send all JSON:API data in request documents with the header
  Content-Type: application/vnd.api+json without any media type
  parameters.

> Clients MUST ignore any parameters for the application/vnd.api+json
  media type received in the Content-Type header of response documents.

We can just check if the content type == `application/vnd.api+json`.