### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [3.1, '3.0', 2.7, 2.6, ruby-head]
+        rails: ['7.0.0', '6.1.0', '6.0.0', '5.2.0', main]
+        exclude:
+          - ruby: ruby-head
+            rails: '6.1.0'
+          - ruby: ruby-head
+            rails: '6.0.0'
+          - ruby: ruby-head
+            rails: '5.2.0'
+          - ruby: 3.1
+            rails: '6.0.0'
+          - ruby: 3.1
+            rails: '5.2.0'
+          - ruby: 3.0
+            rails: main
+          - ruby: 3.0
+            rails: '6.0.0'
+          - ruby: 3.0
+            rails: '5.2.0'
+          - ruby: 2.7
+            rails: main
+          - ruby: 2.7
+            rails: '5.2.0'
+          - ruby: 2.6
+            rails: main
+          - ruby: 2.6
+            rails: '7.0.0'
+          - ruby: 2.6
+            rails: '6.1.0'
+          - ruby: 2.6
+            rails: '6.0.0'
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 rails_version = ENV['RAILS_VERSION'] || "default"
 rails =
   case rails_version
-  when 'master'
+  when 'main'
     { github: 'rails/rails' }
   when 'default'
     '>= 5.0'
@@ -12,5 +12,13 @@ rails =
   end
 
 gem 'rails', rails
+
+# Required for Rails 6.1.x with Ruby 3.1+
+if RUBY_VERSION >= '3.1'
+  gem 'net-smtp', require: false
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
+end
+
 
 gemspec

--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -17,11 +17,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jsonapi-rb', '~> 0.5.0'
   spec.add_dependency 'jsonapi-parser', '~> 0.1.0'
 
-  spec.add_development_dependency 'rails', '~> 5.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
-  spec.add_development_dependency 'rake',        '~> 11.3'
+  spec.add_development_dependency 'rails', '>= 5.0'
+  spec.add_development_dependency 'sqlite3', '>= 1.3'
+  spec.add_development_dependency 'rake',        '>= 11.3'
   spec.add_development_dependency 'rspec-rails', '~> 3.5'
   spec.add_development_dependency 'with_model',  '~> 2.0'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'pry-byebug'
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,7 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+if Rails.application.config.respond_to?(:assets)
+  Rails.application.config.assets.version = '1.0'
+end
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/spec/dummy/config/storage.yml
+++ b/spec/dummy/config/storage.yml
@@ -1,0 +1,8 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+


### PR DESCRIPTION
This PR migrates CI from TravisCI.org, which is no longer operational, to GitHub Actions.  In addition to basic setup it:

1. Adds a number of more recent Ruby and Rails versions
2. Loosens the restrictions in the gemspec to enable those more recent versions to bundle
3. Makes minor changes to the dummy Rails app to allow it to work with Rails 7
4. Conditionally explicitly includes the net-* mail gems for the Ruby 3.1 / Rails 6.1.x combination
5. Switches the Rails references from `master` to `main` in line with the `rails/rails` renaming of that branch.

Everything runs green.

I didn't attempt to pull over the Code Climate integration, although it looks like there's a suitably packaged action [here](https://github.com/paambaati/codeclimate-action) that would be easy enough to incorporate.