### PR TITLE
Remove Rails version check

### DIFF
--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -39,11 +39,7 @@ module JSONAPI
       end
 
       def register_parameter_parser
-        if ::Rails::VERSION::MAJOR >= 5
-          ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
-        else
-          ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] = PARSER
-        end
+        ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
       end
 
       # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
As per gemspec, this gem supports Rails 5.x

This commit removes a check for an older version of Rails no longer supported