### PR TITLE
Support Rails' `parsed_body` in Integration tests

### DIFF
--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -49,7 +49,9 @@ module JSONAPI
 
       def register_encoder
         ActiveSupport.on_load(:action_dispatch_integration_test) do
-          register_encoder :jsonapi, response_parser: ->(body) { JSON.parse(body) }
+          register_encoder :jsonapi,
+            param_encoder: -> (params) { params.to_json },
+            response_parser: -> (body) { JSON.parse(body) }
         end
       end
 

--- a/lib/jsonapi/rails/railtie.rb
+++ b/lib/jsonapi/rails/railtie.rb
@@ -23,6 +23,7 @@ module JSONAPI
       initializer 'jsonapi-rails.init' do |app|
         register_mime_type
         register_parameter_parser
+        register_encoder
         register_renderers
         ActiveSupport.on_load(:action_controller) do
           require 'jsonapi/rails/controller'
@@ -43,6 +44,12 @@ module JSONAPI
           ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
         else
           ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] = PARSER
+        end
+      end
+
+      def register_encoder
+        ActiveSupport.on_load(:action_dispatch_integration_test) do
+          register_encoder :jsonapi, response_parser: ->(body) { JSON.parse(body) }
         end
       end
 

--- a/spec/parsed_body_spec.rb
+++ b/spec/parsed_body_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe ActionController::Base, type: :controller, if: Rails.version >= '6.0' do
+  controller do
+    def index
+      render jsonapi: nil
+    end
+  end
+
+  subject(:parsed_body) { response.parsed_body }
+
+  it 'allows using parsed_body in ActionController::TestCase' do
+    get :index
+
+    expect(parsed_body).to eq(JSON.parse(response.body))
+  end
+end


### PR DESCRIPTION
Ref: https://api.rubyonrails.org/classes/ActionDispatch/TestResponse.html

Close #140