### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/jsonapi-rails.gemspec
+++ b/jsonapi-rails.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/jsonapi-rb/jsonapi-rails'
   spec.license       = 'MIT'
 
+  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
+
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/